### PR TITLE
Added tests for filter method and fixed index resetting issue bug

### DIFF
--- a/src/main/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilter.java
+++ b/src/main/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilter.java
@@ -40,7 +40,7 @@ public class LogFlowFilter {
         int activeRegexCount = 0;
 
         //advanced setup
-        boolean advancedRegexLock = false;
+        boolean advancedRegexIsActive = false;
         LogFlowInputAdvanced activeConfig = null;
 
 
@@ -50,7 +50,7 @@ public class LogFlowFilter {
             String line = lineWithOffset.getLine();
 
             //check if advanced regex is currently active
-            if (advancedRegexLock) {
+            if (advancedRegexIsActive) {
                 if (line.matches(activeConfig.getEndMark())) {
                     //end mark found
                     boolean display = activeConfig.getNumberOfLineToDisplay() == activeRegexCount + 1; // line 0 is start mark
@@ -61,7 +61,7 @@ public class LogFlowFilter {
                         result.add(new LineOutput(activeConfig.getEndMark(), line, lineIndex, activeConfig.getDeleteMark(), LineType.END_MARK, lineWithOffset.getOffset(), display));
                     }
 
-                    advancedRegexLock = false;
+                    advancedRegexIsActive = false;
 
                     activeRegexCount = 0; // reset count to zero for the next iteration and continue
                     activeConfig = null;
@@ -76,7 +76,7 @@ public class LogFlowFilter {
                         result.add(new LineOutput(activeConfig.getStartMark(), line, lineIndex, activeConfig.getDeleteMark(), LineType.LIMIT_REACHED_LINE, lineWithOffset.getOffset(), display));
 
 
-                        advancedRegexLock = false;
+                        advancedRegexIsActive = false;
 
                         activeConfig = null;
 
@@ -138,7 +138,7 @@ public class LogFlowFilter {
                             result.add(new LineOutput(advancedConfig.getStartMark(), line, lineIndex, advancedConfig.getDeleteMark(), LineType.START_MARK, lineWithOffset.getOffset(), display));
                         }
                         activeConfig = advancedConfig;
-                        advancedRegexLock = true;
+                        advancedRegexIsActive = true;
                         break;
                     }
 

--- a/src/main/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilter.java
+++ b/src/main/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilter.java
@@ -63,8 +63,10 @@ public class LogFlowFilter {
 
                     advancedRegexLock = false;
 
-                    activeRegexCount = 0;
+                    activeRegexCount = 0; // reset count to zero for the next iteration and continue
                     activeConfig = null;
+                    lineIndex++;
+                    continue;
                 } else {
                     // filling content of an advanced regex
 
@@ -79,6 +81,8 @@ public class LogFlowFilter {
                         activeConfig = null;
 
                         activeRegexCount = 0;
+                        lineIndex++;
+                        continue;
                     } else {
                         result.add(new LineOutput(activeConfig.getStartMark(), line, lineIndex, activeConfig.getDeleteMark(), LineType.CONTENT_LINE, lineWithOffset.getOffset(), display));
                     }

--- a/src/main/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilter.java
+++ b/src/main/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilter.java
@@ -72,25 +72,26 @@ public class LogFlowFilter {
 
                     boolean display = activeConfig.getNumberOfLineToDisplay() == activeRegexCount + 1; // line 0 is start mark
                     if (activeRegexCount >= activeConfig.getMaxContentLength()) {
-                        //end regex because of reaching the max limit
+                        // end regex because of reaching the max limit
                         result.add(new LineOutput(activeConfig.getStartMark(), line, lineIndex, activeConfig.getDeleteMark(), LineType.LIMIT_REACHED_LINE, lineWithOffset.getOffset(), display));
 
 
                         advancedRegexIsActive = false;
 
-                        activeConfig = null;
-
                         activeRegexCount = 0;
+                        activeConfig = null;
                         lineIndex++;
                         continue;
                     } else {
+                        // adding a "content" line to the regex found, regex is still active after this addition
                         result.add(new LineOutput(activeConfig.getStartMark(), line, lineIndex, activeConfig.getDeleteMark(), LineType.CONTENT_LINE, lineWithOffset.getOffset(), display));
+                        activeRegexCount++;
+                        lineIndex++;
+                        continue; //skipping to next line
                     }
 
                 }
-                activeRegexCount++;
-                lineIndex++;
-                continue; //skipping to next line
+
             }
 
             //matching first config, first come, first served principal

--- a/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
@@ -137,5 +137,55 @@ class LogFlowFilterTest {
 
     }
 
+    @Test
+    void filter_withAdvancedConfigDisplayLastLine_shouldSuccessfullyReturnLines() {
+        List<LineWithOffset> lines = new ArrayList<>();
+
+        lines.add(new LineWithOffset("START", 0));
+        lines.add(new LineWithOffset("SOME CONTENT 1", 1));
+        lines.add(new LineWithOffset("NOW", 2));
+        lines.add(new LineWithOffset("END", 3));
+
+        lines.add(new LineWithOffset("START", 4));
+        lines.add(new LineWithOffset("SOME CONTENT 2", 5));
+        lines.add(new LineWithOffset("YOU", 6));
+        lines.add(new LineWithOffset("END", 7));
+
+        lines.add(new LineWithOffset("START", 8));
+        lines.add(new LineWithOffset("SOME CONTENT 3", 9));
+        lines.add(new LineWithOffset("SEE", 10));
+        lines.add(new LineWithOffset("END", 11));
+
+        lines.add(new LineWithOffset("START", 12));
+        lines.add(new LineWithOffset("SOME CONTENT 4", 13));
+        lines.add(new LineWithOffset("ME", 14));
+        lines.add(new LineWithOffset("END", 15));
+
+        LogFlowInputAdvanced advancedConfig = new LogFlowInputAdvanced("START", "END", false, 30, 3);
+
+        List<LogFlowInput> configs = new ArrayList<>();
+        configs.add(advancedConfig);
+
+        List<LineOutput> result = LogFlowFilter.filter(lines, configs);
+
+        List<LineOutput> toDisplayResult = result.stream()
+                .filter(LineOutput::getDisplay)
+                .collect(Collectors.toList());
+
+
+        //  expected
+        List<String> expectedLines = new ArrayList<>();
+        expectedLines.add("END");
+        expectedLines.add("END");
+        expectedLines.add("END");
+        expectedLines.add("END");
+
+        String lineSeparator = System.lineSeparator();
+        assertEquals(String.join(lineSeparator, expectedLines), toDisplayResult.stream()
+                .map(LineOutput::getLine)
+                .collect(Collectors.joining(lineSeparator)));
+
+    }
+
 
 }

--- a/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.LogFlowVisualizer;
 
 import io.jenkins.plugins.LogFlowVisualizer.input.LogFlowInput;
 import io.jenkins.plugins.LogFlowVisualizer.input.LogFlowInputAdvanced;
+import io.jenkins.plugins.LogFlowVisualizer.input.LogFlowInputSimple;
 import io.jenkins.plugins.LogFlowVisualizer.model.LineOutput;
 import io.jenkins.plugins.LogFlowVisualizer.model.LineWithOffset;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,42 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 class LogFlowFilterTest {
+
+    @Test
+    void filter_withSimpleConfig_shouldSuccessfullyReturnLines(){
+        List<LineWithOffset> lines = new ArrayList<>();
+
+        lines.add(new LineWithOffset("Starting logs", 0));
+        lines.add(new LineWithOffset("Building", 1));
+        lines.add(new LineWithOffset("Testing", 2));
+        lines.add(new LineWithOffset("Deploying", 3));
+        lines.add(new LineWithOffset("Finished", 4));
+        lines.add(new LineWithOffset("Result: SUCCESS", 5));
+
+
+        lines.add(new LineWithOffset("Starting logs", 0));
+        lines.add(new LineWithOffset("Building", 1));
+        lines.add(new LineWithOffset("Testing", 2));
+        lines.add(new LineWithOffset("Deploying", 3));
+        lines.add(new LineWithOffset("Finished", 4));
+        lines.add(new LineWithOffset("Result: FAILURE", 5));
+
+        LogFlowInput simpleConfig = new LogFlowInputSimple("Result: .*", false);
+
+        List<LogFlowInput> configs = new ArrayList<>();
+        configs.add(simpleConfig);
+
+        List<LineOutput> result = LogFlowFilter.filter(lines, configs);
+
+        List<LineOutput> toDisplayResult = result.stream()
+                .filter(LineOutput::getDisplay)
+                .collect(Collectors.toList());
+
+        assertEquals(2, toDisplayResult.size());
+        assertEquals("Result: SUCCESS\nResult: FAILURE", toDisplayResult.stream()
+                .map(LineOutput::getLine)
+                .collect(Collectors.joining("\n")));
+    }
 
     @Test
     void filter_withAdvancedConfig_shouldSuccessfullyReturnLines() {

--- a/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
@@ -12,10 +12,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
+
 class LogFlowFilterTest {
 
     @Test
-    void filter_withSimpleConfig_shouldSuccessfullyReturnLines(){
+    void filter_withSimpleConfig_shouldSuccessfullyReturnLines() {
         List<LineWithOffset> lines = new ArrayList<>();
 
         lines.add(new LineWithOffset("Starting logs", 0));
@@ -44,10 +45,46 @@ class LogFlowFilterTest {
                 .filter(LineOutput::getDisplay)
                 .collect(Collectors.toList());
 
-        assertEquals(2, toDisplayResult.size());
-        assertEquals("Result: SUCCESS\nResult: FAILURE", toDisplayResult.stream()
+
+        // expected
+        List<String> expectedLines = new ArrayList<>();
+        expectedLines.add("Result: SUCCESS");
+        expectedLines.add("Result: FAILURE");
+
+        String lineSeparator = System.lineSeparator();
+
+        assertEquals(String.join(lineSeparator, expectedLines), toDisplayResult.stream()
                 .map(LineOutput::getLine)
-                .collect(Collectors.joining("\n")));
+                .collect(Collectors.joining(lineSeparator)));
+    }
+
+    @Test
+    void filter_withSimpleConfig_shouldReturnNoLines() {
+        List<LineWithOffset> lines = new ArrayList<>();
+
+        lines.add(new LineWithOffset("Starting logs", 0));
+        lines.add(new LineWithOffset("Building", 1));
+        lines.add(new LineWithOffset("Testing", 2));
+        lines.add(new LineWithOffset("Deploying", 3));
+        lines.add(new LineWithOffset("Finished", 4));
+        lines.add(new LineWithOffset("Result: SUCCESS", 5));
+
+        LogFlowInput simpleConfig = new LogFlowInputSimple("Nonexistent pattern", false);
+
+        List<LogFlowInput> configs = new ArrayList<>();
+        configs.add(simpleConfig);
+
+        List<LineOutput> result = LogFlowFilter.filter(lines, configs);
+
+        List<LineOutput> toDisplayResult = result.stream()
+                .filter(LineOutput::getDisplay)
+                .collect(Collectors.toList());
+
+        List<String> expectedLines = new ArrayList<>();
+        String lineSeparator = System.lineSeparator();
+        assertEquals(String.join(lineSeparator, expectedLines), toDisplayResult.stream()
+                .map(LineOutput::getLine)
+                .collect(Collectors.joining(lineSeparator)));
     }
 
     @Test
@@ -85,10 +122,20 @@ class LogFlowFilterTest {
                 .filter(LineOutput::getDisplay)
                 .collect(Collectors.toList());
 
-        assertEquals(4, toDisplayResult.size());
-        assertEquals("NOW YOU SEE ME", toDisplayResult.stream()
+
+        //  expected
+        List<String> expectedLines = new ArrayList<>();
+        expectedLines.add("NOW");
+        expectedLines.add("YOU");
+        expectedLines.add("SEE");
+        expectedLines.add("ME");
+
+        String lineSeparator = System.lineSeparator();
+        assertEquals(String.join(lineSeparator, expectedLines), toDisplayResult.stream()
                 .map(LineOutput::getLine)
-                .collect(Collectors.joining(" ")));
+                .collect(Collectors.joining(lineSeparator)));
 
     }
+
+
 }

--- a/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
@@ -187,5 +187,51 @@ class LogFlowFilterTest {
 
     }
 
+    @Test
+    void filter_withAdvancedConfigDisplayFirstLine_shouldSuccessfullyReturnLines() {
+        List<LineWithOffset> lines = new ArrayList<>();
+
+        lines.add(new LineWithOffset("START", 0));
+        lines.add(new LineWithOffset("SOME CONTENT 1", 1));
+        lines.add(new LineWithOffset("NOW", 2));
+        lines.add(new LineWithOffset("END", 3));
+
+        lines.add(new LineWithOffset("START", 4));
+        lines.add(new LineWithOffset("SOME CONTENT 2", 5));
+        lines.add(new LineWithOffset("YOU", 6));
+        lines.add(new LineWithOffset("END", 7));
+
+        lines.add(new LineWithOffset("START", 8));
+        lines.add(new LineWithOffset("SOME CONTENT 3", 9));
+        lines.add(new LineWithOffset("SEE", 10));
+        lines.add(new LineWithOffset("END", 11));
+
+        lines.add(new LineWithOffset("START", 12));
+        lines.add(new LineWithOffset("SOME CONTENT 4", 13));
+        lines.add(new LineWithOffset("ME", 14));
+        lines.add(new LineWithOffset("END", 15));
+
+        LogFlowInputAdvanced advancedConfig = new LogFlowInputAdvanced("START", "END", false, 30, 0);
+
+        List<LogFlowInput> configs = new ArrayList<>();
+        configs.add(advancedConfig);
+
+        List<LineOutput> result = LogFlowFilter.filter(lines, configs);
+
+        List<LineOutput> toDisplayResult = result.stream()
+                .filter(LineOutput::getDisplay)
+                .collect(Collectors.toList());
+
+        List<String> expectedLines = new ArrayList<>();
+        expectedLines.add("START");
+        expectedLines.add("START");
+        expectedLines.add("START");
+        expectedLines.add("START");
+        String lineSeparator = System.lineSeparator();
+        assertEquals(String.join(lineSeparator, expectedLines), toDisplayResult.stream()
+                .map(LineOutput::getLine)
+                .collect(Collectors.joining(lineSeparator)));
+    }
+
 
 }

--- a/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
@@ -1,0 +1,57 @@
+package io.jenkins.plugins.LogFlowVisualizer;
+
+import io.jenkins.plugins.LogFlowVisualizer.input.LogFlowInput;
+import io.jenkins.plugins.LogFlowVisualizer.input.LogFlowInputAdvanced;
+import io.jenkins.plugins.LogFlowVisualizer.model.LineOutput;
+import io.jenkins.plugins.LogFlowVisualizer.model.LineWithOffset;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+class LogFlowFilterTest {
+
+    @Test
+    void filter_withAdvancedConfig_shouldSuccessfullyReturnLines() {
+        List<LineWithOffset> lines = new ArrayList<>();
+
+        lines.add(new LineWithOffset("START", 0));
+        lines.add(new LineWithOffset("SOME CONTENT 1", 1));
+        lines.add(new LineWithOffset("NOW", 2));
+        lines.add(new LineWithOffset("END", 3));
+
+        lines.add(new LineWithOffset("START", 4));
+        lines.add(new LineWithOffset("SOME CONTENT 2", 5));
+        lines.add(new LineWithOffset("YOU", 6));
+        lines.add(new LineWithOffset("END", 7));
+
+        lines.add(new LineWithOffset("START", 8));
+        lines.add(new LineWithOffset("SOME CONTENT 3", 9));
+        lines.add(new LineWithOffset("SEE", 10));
+        lines.add(new LineWithOffset("END", 11));
+
+        lines.add(new LineWithOffset("START", 12));
+        lines.add(new LineWithOffset("SOME CONTENT 4", 13));
+        lines.add(new LineWithOffset("ME", 14));
+        lines.add(new LineWithOffset("END", 15));
+
+        LogFlowInputAdvanced advancedConfig = new LogFlowInputAdvanced("START", "END", false, 30, 2);
+
+        List<LogFlowInput> configs = new ArrayList<>();
+        configs.add(advancedConfig);
+
+        List<LineOutput> result = LogFlowFilter.filter(lines, configs);
+
+        List<LineOutput> toDisplayResult = result.stream()
+                .filter(LineOutput::getDisplay)
+                .collect(Collectors.toList());
+
+        assertEquals(4, toDisplayResult.size());
+        assertEquals("NOW YOU SEE ME", toDisplayResult.stream()
+                .map(LineOutput::getLine)
+                .collect(Collectors.joining(" ")));
+
+    }
+}

--- a/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
+++ b/src/test/java/io/jenkins/plugins/LogFlowVisualizer/LogFlowFilterTest.java
@@ -11,8 +11,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+
+// the following are unit tests for filter function.
+// NOTE: The offsets in these tests don't reflect real scenario and are just random sequential numbers, as we don't use them here
 class LogFlowFilterTest {
 
     @Test


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

### Added tests for filter method and fixed index resetting issue  

Added 5 test scenarios testing the correct behavior of the plugin.

There was a reported bug, displaying the wrong line found in advanced regex mark (apart from the first one). The error was incorrect resetting of the line to display index.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
